### PR TITLE
Use checkAdmin instead of custom denied response.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tennu-eval",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A plugin for the Tennu IRC framework. Evaluates javascript.",
   "main": "plugin.js",
   "repository": {
@@ -12,6 +12,7 @@
     "postversion": "git push && git push --tags && npm publish"
   },
   "author": "Victorio Berra",
+  "contributors": ["Ryan (Havvy) Scheel"],
   "license": "ISC",
   "dependencies": {}
 }

--- a/plugin.js
+++ b/plugin.js
@@ -2,30 +2,18 @@ const TennuEval = {
     requires: ["admin"],
     init: function(client, imports) {
         const requiresAdmin = imports.admin.requiresAdmin;
+        const checkAdmin = imports.admin.checkAdmin;
 
         function evalIntoResponse (toEval) {
             return ("<< " + eval(toEval)).split("\n");
-        }
-
-        function adminFail(nickname, hostname) {
-            return {
-                intent: 'notice',
-                query: true,
-                message: ['Restricted access.', format('Logged: %s@%s.', nickname, hostname)]
-            };
         }
 
         return {
             handlers: {
                 "privmsg": function (privmsg) {
                     if (/^\>\>/.test(privmsg.message)) {
-                        return imports.admin.isAdmin(privmsg.hostmask)
-                        .then(function(isAdmin) {
-                            if (!isAdmin) {
-                                return adminFail(privmsg.nickname, privmsg.hostmask.hostname);
-                            } else {
-                                return evalIntoResponse(privmsg.message.slice(2));
-                            }
+                        return checkAdmin(privmsg, function () {
+                            return evalIntoResponse(privmsg.message.slice(2));
                         });
                     }
                 },


### PR DESCRIPTION
This removes the custom permission denied function in favor of the unified denied response from other users of the admin plugin.

This is a "breaking change" for two reasons.
1. It requires a newer version of the admin plugin than the previous version.
2. It changes the user-facing message when an eval is denied.

Also fun is that this removes 14 lines of code. :smiley_cat: 
